### PR TITLE
Refactor: handle large playlist transfers and prevent duplicate Tidal…

### DIFF
--- a/main.py
+++ b/main.py
@@ -11,6 +11,8 @@ CLIENT_ID: str = os.getenv("SPOTIPY_CLIENT_ID") or ""
 CLIENT_SECRET: str = os.getenv("SPOTIPY_CLIENT_SECRET") or ""
 REDIRECT_URI: str = os.getenv("SPOTIPY_REDIRECT_URI") or ""
 SCOPE: str = os.getenv("SPOTIPY_CLIENT_SCOPE") or ""
+batch_size = 100
+
 
 def run_conversion(spotify_playlist: str, tidal_playlist: str):
     sc: SpotifyScanner = SpotifyScanner(
@@ -33,9 +35,11 @@ def run_conversion(spotify_playlist: str, tidal_playlist: str):
             print(f"Skipped track {song.title} {song.artist}")
             continue
         tids.append(res)
-            
-    td.add_to_playlist(tidal_playlist, tids)
-    
+
+    playlist = td.get_or_create_playlist(tidal_playlist)
+    for i in range(0, len(tids), batch_size):
+        td.add_to_playlist(playlist, tids[i:i+batch_size])
+
 if __name__ == "__main__":
     if len(sys.argv) < 3:
         print("Include spotify playlist id and tidal playlist name")

--- a/spotify_scanner.py
+++ b/spotify_scanner.py
@@ -17,7 +17,7 @@ class SpotifyScanner:
         self.__redirect_uri: str = redirect_uri
         self.__scope: str = scope
         self.sp: spotipy.Spotify
-        self.__query_limit: int = 50
+        self.__query_limit: int = 100
         self.__filecontent: list[Song] = []
         self.filename = lambda x: f".spotify_{x}.json"
         
@@ -70,9 +70,9 @@ class SpotifyScanner:
         offset: int = 0
         while keeprunning:
             if playlist == "likes":
-                r: Any = self.sp.current_user_saved_tracks(limit=50, offset=offset)
+                r: Any = self.sp.current_user_saved_tracks(limit=self.__query_limit, offset=offset)
             else:
-                r: Any = self.sp.playlist_tracks(playlist)
+                r: Any = self.sp.playlist_tracks(playlist, limit=self.__query_limit, offset=offset)
             count = self.__append_tracks(r)
             keeprunning = count == self.__query_limit
             offset += count

--- a/tidal_updater.py
+++ b/tidal_updater.py
@@ -35,8 +35,16 @@ class TidalUpdater:
             pass
         
         return tidal_id
-    
-    def add_to_playlist(self, playlist_name: str, tids: list[str]):
-        playlist = self.session.user.create_playlist(playlist_name, "Songs saved from spotify")
-        playlist.add(tids)
+
+    def add_to_playlist(self, playlist, tids: list[str]):
         
+        playlist.add(tids)   
+
+    def get_or_create_playlist(self, playlist_name: str):
+
+        for pl in self.session.user.playlists():
+            if pl.name == playlist_name:
+                return pl
+        return self.session.user.create_playlist(playlist_name, "Songs saved from spotify")
+
+   


### PR DESCRIPTION
- Update SpotifyScanner to use proper pagination for both liked songs and playlists, ensuring all tracks are fetched and transferred, not just the first 100.
- Refactor TidalUpdater:
    - Add get_or_create_playlist to reuse an existing Tidal playlist by name or create it if it does not exist.
    - Change add_to_playlist to accept a playlist object, so all tracks are added to a single playlist regardless of batching.
- Update main script logic to fetch or create the Tidal playlist once and add all tracks in batches to that playlist.
- These changes ensure that large Spotify playlists are fully transferred into a single Tidal playlist, and fix the bug where multiple Tidal playlists with the same name were created for each batch.